### PR TITLE
docs: add v1 and WAICA 2026 links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # InternAgentHarness
 
+🎉 我们的技术报告已被 [**WAICA 2026**](https://waica2026.worldaic.com.cn/program/program-glance/) 接收！
+
+📄 技术报告：[InternBootcamp Technical Report: Boosting LLM Reasoning with Verifiable Task Scaling](https://arxiv.org/abs/2508.08636)
+
+📦 历史版本：[InternBootcamp v1](https://github.com/InternLM/InternBootcamp/tree/v1)
+
 <div align="center">
   <img src="./figs/overview.png" width="800" alt="InternAgentHarness Overview"/>
 </div>

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # InternAgentHarness
 
-🎉 我们的技术报告已被 [**WAICA 2026**](https://waica2026.worldaic.com.cn/program/program-glance/) 接收！
+🎉 基于 **InternBootcamp v1 版本** 的技术报告已被 [**WAICA 2026**](https://waica2026.worldaic.com.cn/program/program-glance/) 接收！
 
 📄 技术报告：[InternBootcamp Technical Report: Boosting LLM Reasoning with Verifiable Task Scaling](https://arxiv.org/abs/2508.08636)
 
-📦 历史版本：[InternBootcamp v1](https://github.com/InternLM/InternBootcamp/tree/v1)
+📦 报告对应代码版本：[InternBootcamp v1](https://github.com/InternLM/InternBootcamp/tree/v1)
 
 <div align="center">
   <img src="./figs/overview.png" width="800" alt="InternAgentHarness Overview"/>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # InternAgentHarness
 
-🎉 基于 **InternBootcamp v1 版本** 的技术报告已被 [**WAICA 2026**](https://waica2026.worldaic.com.cn/program/program-glance/) 接收！
+🎉 基于 **InternBootcamp v1** 的技术报告已被 [**WAICA 2026**](https://waica2026.worldaic.com.cn/program/program-glance/) 接收！
 
 📄 技术报告：[InternBootcamp Technical Report: Boosting LLM Reasoning with Verifiable Task Scaling](https://arxiv.org/abs/2508.08636)
 


### PR DESCRIPTION
## Summary

- Clarify that the technical report is based on the InternBootcamp v1 codebase and was accepted by WAICA 2026.
- Add the canonical technical report link: https://arxiv.org/abs/2508.08636
- Add the corresponding official v1 code branch: https://github.com/InternLM/InternBootcamp/tree/v1

## Verification

- Built from the latest main commit 757793afb5f181080601daaef46d7dd7ed14c013.
- README-only change: 6 added lines.